### PR TITLE
feat: add support for Request/Response Log Record obscurers

### DIFF
--- a/logging_http_client/__init__.py
+++ b/logging_http_client/__init__.py
@@ -64,6 +64,8 @@ from requests.sessions import Session, session  # noqa: F401
 # noinspection PyUnresolvedReferences
 from requests.status_codes import codes  # noqa: F401
 
+# noinspection PyUnresolvedReferences
+from http_log_record import HttpLogRecord  # noqa: F401
 from logging_http_client_class import LoggingHttpClient
 
 

--- a/logging_http_client/http_log_record.py
+++ b/logging_http_client/http_log_record.py
@@ -3,7 +3,12 @@ from typing import Any, Dict, Union
 
 from requests.models import PreparedRequest, Response
 
-from logging_http_client_config import is_request_body_logging_enabled, is_response_body_logging_enabled
+from logging_http_client_config_globals import (
+    is_request_body_logging_enabled,
+    is_response_body_logging_enabled,
+    get_request_log_record_obscurer,
+    get_response_log_record_obscurer,
+)
 
 # Define Primitive type
 Primitive = Union[int, float, str, bool]
@@ -52,6 +57,9 @@ class HttpLogRecord(BaseLogRecord):
             else:
                 record.request_body = request.body
 
+        obscurer = get_request_log_record_obscurer()
+        record = obscurer(record) if obscurer is not None else record
+
         return {"http": record.to_dict()}
 
     @staticmethod
@@ -65,5 +73,8 @@ class HttpLogRecord(BaseLogRecord):
 
         if response.content and is_response_body_logging_enabled():
             record.response_body = response.content.decode()
+
+        obscurer = get_response_log_record_obscurer()
+        record = obscurer(record) if obscurer is not None else record
 
         return {"http": record.to_dict()}

--- a/logging_http_client/http_session.py
+++ b/logging_http_client/http_session.py
@@ -6,7 +6,7 @@ from requests import Session, Response, Request, PreparedRequest
 
 from http_headers import X_SOURCE_HEADER, X_REQUEST_ID_HEADER, HEADERS_KWARG
 from http_log_record import HttpLogRecord
-from logging_http_client_config import (
+from logging_http_client_config_globals import (
     is_request_logging_enabled,
     is_response_logging_enabled,
     get_custom_request_logging_hook,

--- a/logging_http_client/logging_http_client_config.py
+++ b/logging_http_client/logging_http_client_config.py
@@ -1,67 +1,62 @@
+"""
+This module contains type definitions for the logging_http_client configuration.
+
+We move the type definitions to a separate file to avoid circular imports.
+"""
+
 import logging
 from typing import Optional, Callable
 
 from requests import Response, PreparedRequest
 
-_request_logging_enabled: bool = True
-_response_logging_enabled: bool = True
-
-_request_body_logging_enabled: bool = False
-_response_body_logging_enabled: bool = False
+import logging_http_client_config_globals
+from logging_http_client import HttpLogRecord
 
 ResponseHookType = Optional[Callable[[logging.Logger, Response], None]]
 RequestHookType = Optional[Callable[[logging.Logger, PreparedRequest], None]]
 
-_request_logging_hook: RequestHookType = None
-_response_logging_hook: ResponseHookType = None
+ResponseLogRecordObscurerType = Optional[Callable[[HttpLogRecord], HttpLogRecord]]
+RequestLogRecordObscurerType = Optional[Callable[[HttpLogRecord], HttpLogRecord]]
 
 
-def get_custom_request_logging_hook() -> RequestHookType:
+def set_request_log_record_obscurer(obscurer: RequestLogRecordObscurerType) -> None:
     """
-    Get the custom hook for logging all requests.
+    Sets an obscurer for all requests logged.
+
+    This is useful for redacting sensitive information from the log records.
+
+    The obscurer will run on the log record JUST BEFORE it is logged by the
+    request logger. When using the request obscurer, you are also responsible
+    for returning the log record in the correct data structure.
     """
-    global _request_logging_hook
-    return _request_logging_hook
+    logging_http_client_config_globals.set_request_log_record_obscurer(obscurer)
 
 
-def get_custom_response_logging_hook() -> ResponseHookType:
+def set_response_log_record_obscurer(obscurer: ResponseLogRecordObscurerType) -> None:
     """
-    Get the custom hook for logging all responses.
+    Sets an obscurer for all responses logged.
+
+    This is useful for redacting sensitive information from the log records.
+
+    The obscurer will run on the log record JUST BEFORE it is logged by the
+    response logger. When using the response obscurer, you are also responsible
+    for returning the log record in the correct data structure.
     """
-    global _response_logging_hook
-    return _response_logging_hook
+    logging_http_client_config_globals.set_response_log_record_obscurer(obscurer)
 
 
 def set_custom_request_logging_hook(hook: RequestHookType) -> None:
     """
     Set a custom hook for logging all requests.
     """
-    global _request_logging_hook
-    _request_logging_hook = hook
+    logging_http_client_config_globals.set_custom_request_logging_hook(hook)
 
 
 def set_custom_response_logging_hook(hook: ResponseHookType) -> None:
     """
     Set a custom hook for logging all responses.
     """
-    global _response_logging_hook
-    _response_logging_hook = hook
-
-
-def is_request_logging_enabled() -> bool:
-    return _request_logging_enabled
-
-
-def is_response_logging_enabled() -> bool:
-    return _response_logging_enabled
-
-
-def is_request_body_logging_enabled() -> bool:
-    return _request_body_logging_enabled
-
-
-def is_response_body_logging_enabled() -> bool:
-    return _response_body_logging_enabled
+    logging_http_client_config_globals.set_custom_response_logging_hook(hook)
 
 
 def disable_request_logging(disabled: bool = True) -> None:
@@ -72,8 +67,7 @@ def disable_request_logging(disabled: bool = True) -> None:
         These has no effect if you have set up custom logging hooks. (i.e.
         these are for modifying the default logging setup)
     """
-    global _request_logging_enabled
-    _request_logging_enabled = not disabled
+    logging_http_client_config_globals.set_request_logging_enabled(not disabled)
 
 
 def disable_response_logging(disabled: bool = True) -> None:
@@ -84,8 +78,7 @@ def disable_response_logging(disabled: bool = True) -> None:
         These has no effect if you have set up custom logging hooks. (i.e.
         these are for modifying the default logging setup)
     """
-    global _response_logging_enabled
-    _response_logging_enabled = not disabled
+    logging_http_client_config_globals.set_response_logging_enabled(not disabled)
 
 
 def enable_request_body_logging(enable: bool = True) -> None:
@@ -96,8 +89,7 @@ def enable_request_body_logging(enable: bool = True) -> None:
         These has no effect if you have set up custom logging hooks. (i.e.
         these are for modifying the default logging setup)
     """
-    global _request_body_logging_enabled
-    _request_body_logging_enabled = enable
+    logging_http_client_config_globals.set_request_body_logging_enabled(enable)
 
 
 def enable_response_body_logging(enable: bool = True) -> None:
@@ -108,5 +100,4 @@ def enable_response_body_logging(enable: bool = True) -> None:
         These has no effect if you have set up custom logging hooks. (i.e.
         these are for modifying the default logging setup)
     """
-    global _response_body_logging_enabled
-    _response_body_logging_enabled = enable
+    logging_http_client_config_globals.set_response_body_logging_enabled(enable)

--- a/logging_http_client/logging_http_client_config_globals.py
+++ b/logging_http_client/logging_http_client_config_globals.py
@@ -1,0 +1,109 @@
+"""
+This module contains the global configuration for the logging_http_client.
+
+We separate the configuration globals and getters from the main configuration module to
+avoid circular imports when using the configuration getters within the implementation code.
+"""
+
+# Request/Response Log Record Obscurers ======================================
+
+_request_log_record_obscurer = None
+_response_log_record_obscurer = None
+
+
+def get_request_log_record_obscurer():
+    global _request_log_record_obscurer
+    return _request_log_record_obscurer
+
+
+def get_response_log_record_obscurer():
+    global _response_log_record_obscurer
+    return _response_log_record_obscurer
+
+
+def set_request_log_record_obscurer(value):
+    global _request_log_record_obscurer
+    _request_log_record_obscurer = value
+
+
+def set_response_log_record_obscurer(value):
+    global _response_log_record_obscurer
+    _response_log_record_obscurer = value
+
+
+# Request/Response Hooks =====================================================
+
+_request_logging_hook = None
+_response_logging_hook = None
+
+
+def get_custom_request_logging_hook():
+    global _request_logging_hook
+    return _request_logging_hook
+
+
+def get_custom_response_logging_hook():
+    global _response_logging_hook
+    return _response_logging_hook
+
+
+def set_custom_request_logging_hook(value):
+    global _request_logging_hook
+    _request_logging_hook = value
+
+
+def set_custom_response_logging_hook(value):
+    global _response_logging_hook
+    _response_logging_hook = value
+
+
+# Request/Response Logging Toggle =============================================
+
+_request_logging_enabled: bool = True
+_response_logging_enabled: bool = True
+
+
+def is_request_logging_enabled() -> bool:
+    global _request_logging_enabled
+    return _request_logging_enabled
+
+
+def is_response_logging_enabled() -> bool:
+    global _response_logging_enabled
+    return _response_logging_enabled
+
+
+def set_request_logging_enabled(value: bool):
+    global _request_logging_enabled
+    _request_logging_enabled = value
+
+
+def set_response_logging_enabled(value: bool):
+    global _response_logging_enabled
+    _response_logging_enabled = value
+
+
+# Request/Response Body Logging Toggle ========================================
+
+_request_body_logging_enabled: bool = False
+_response_body_logging_enabled: bool = False
+
+
+def is_request_body_logging_enabled() -> bool:
+    global _request_body_logging_enabled
+    return _request_body_logging_enabled
+
+
+def is_response_body_logging_enabled() -> bool:
+    global _response_body_logging_enabled
+    return _response_body_logging_enabled
+
+
+def set_request_body_logging_enabled(value: bool):
+    global _request_body_logging_enabled
+    _request_body_logging_enabled = value
+
+
+def set_response_body_logging_enabled(value: bool):
+    global _response_body_logging_enabled
+    _response_body_logging_enabled = value

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,9 @@ def reset_library_globals_after_each_test():
     As I keep modifying the global (static) context and processors in the ContextualLogger in each
     test, I need to clean them up after each test to avoid memory leaks or undesired side effects.
     """
+    logging_http_client_config.set_request_log_record_obscurer(None)
+    logging_http_client_config.set_response_log_record_obscurer(None)
+
     logging_http_client_config.set_custom_request_logging_hook(None)
     logging_http_client_config.set_custom_response_logging_hook(None)
 

--- a/tests/unit/test_logging_default_config.py
+++ b/tests/unit/test_logging_default_config.py
@@ -5,6 +5,8 @@ from logging_http_client_config import (
     enable_request_body_logging,
     disable_response_logging,
     enable_response_body_logging,
+)
+from logging_http_client_config_globals import (
     is_request_logging_enabled,
     is_response_logging_enabled,
     is_request_body_logging_enabled,

--- a/tests/unit/test_logging_hooks.py
+++ b/tests/unit/test_logging_hooks.py
@@ -1,19 +1,24 @@
 from requests import Response, PreparedRequest
 
 from logging_http_client_config import (
-    get_custom_request_logging_hook,
-    get_custom_response_logging_hook,
     set_custom_request_logging_hook,
     set_custom_response_logging_hook,
 )
+from logging_http_client_config_globals import (
+    get_custom_request_logging_hook,
+    get_custom_response_logging_hook,
+)
 
 
-def mock_request_hook(request: PreparedRequest) -> None:
+def mock_request_hook(_, request: PreparedRequest) -> None:
     print(f"Request method: {request.method}")
 
 
-def mock_response_hook(response: Response) -> None:
+def mock_response_hook(_, response: Response) -> None:
     print(f"Response status code: {response.status_code}")
+
+
+# Global Getters and Setters Smoke Tests ======================================
 
 
 def test_default_request_logging_hook_is_none():
@@ -46,6 +51,9 @@ def test_reset_response_logging_hook():
     assert get_custom_response_logging_hook() is None
 
 
+# Functionality Tests =========================================================
+
+
 def test_request_logging_hook_functionality(capsys):
     set_custom_request_logging_hook(mock_request_hook)
 
@@ -53,7 +61,7 @@ def test_request_logging_hook_functionality(capsys):
     request.method = "GET"
 
     hook = get_custom_request_logging_hook()
-    hook(request)
+    hook(None, request)
 
     captured = capsys.readouterr()
     assert "Request method: GET" in captured.out
@@ -66,7 +74,7 @@ def test_response_logging_hook_functionality(capsys):
     response.status_code = 200
 
     hook = get_custom_response_logging_hook()
-    hook(response)
+    hook(None, response)
 
     captured = capsys.readouterr()
     assert "Response status code: 200" in captured.out

--- a/tests/unit/test_logging_obscurers.py
+++ b/tests/unit/test_logging_obscurers.py
@@ -1,0 +1,90 @@
+from logging_http_client import HttpLogRecord
+from logging_http_client_config import (
+    set_request_log_record_obscurer,
+    set_response_log_record_obscurer,
+)
+from logging_http_client_config_globals import (
+    get_request_log_record_obscurer,
+    get_response_log_record_obscurer,
+)
+
+
+def mock_request_log_record_obscurer(record: HttpLogRecord) -> HttpLogRecord:
+    record.request_method = "REDACTED"
+    if record.request_headers.get("Authorization") is not None:
+        record.request_headers["Authorization"] = "Bearer ****"
+    return record
+
+
+def mock_response_log_record_obscurer(record: HttpLogRecord) -> HttpLogRecord:
+    record.response_status = 999
+    if record.response_body is not None:
+        record.response_body = record.response_body.replace("SENSITIVE", "****")
+    return record
+
+
+# Global Getters and Setters Smoke Tests ======================================
+
+
+def test_default_request_log_record_obscurer_is_none():
+    assert get_request_log_record_obscurer() is None
+
+
+def test_default_response_log_record_obscurer_is_none():
+    assert get_response_log_record_obscurer() is None
+
+
+def test_set_request_log_record_obscurer():
+    set_request_log_record_obscurer(mock_request_log_record_obscurer)
+    assert get_request_log_record_obscurer() is mock_request_log_record_obscurer
+
+
+def test_set_response_log_record_obscurer():
+    set_response_log_record_obscurer(mock_response_log_record_obscurer)
+    assert get_response_log_record_obscurer() is mock_response_log_record_obscurer
+
+
+def test_reset_request_log_record_obscurer():
+    set_request_log_record_obscurer(mock_request_log_record_obscurer)
+    set_request_log_record_obscurer(None)
+    assert get_request_log_record_obscurer() is None
+
+
+def test_reset_response_log_record_obscurer():
+    set_response_log_record_obscurer(mock_response_log_record_obscurer)
+    set_response_log_record_obscurer(None)
+    assert get_response_log_record_obscurer() is None
+
+
+# Functionality Tests =========================================================
+
+
+def test_request_log_record_obscurer_functionality():
+    set_request_log_record_obscurer(mock_request_log_record_obscurer)
+
+    http_log_record = HttpLogRecord(
+        request_method="GET",
+        request_headers={"Authorization": "Bearer super-secret-token"},
+        request_body="some request body that should not be changed",
+    )
+
+    obscurer = get_request_log_record_obscurer()
+    obscured_record: HttpLogRecord = obscurer(http_log_record)
+
+    assert obscured_record.request_method == "REDACTED"
+    assert obscured_record.request_headers["Authorization"] == "Bearer ****"
+    assert obscured_record.request_body == "some request body that should not be changed"
+
+
+def test_response_log_record_obscurer_functionality():
+    set_response_log_record_obscurer(mock_response_log_record_obscurer)
+
+    http_log_record = HttpLogRecord(
+        response_status=200,
+        response_body="some response body with SENSITIVE information",
+    )
+    obscurer = get_response_log_record_obscurer()
+    obscured_record: HttpLogRecord = obscurer(http_log_record)
+
+    assert obscured_record.response_status == 999
+    assert obscured_record.response_body == "some response body with **** information"


### PR DESCRIPTION
### Summary

The library now provides a way to obscure sensitive data in the request or response log records. This is useful when you
want to log the request or response body but want to obscure sensitive data such as passwords, tokens, etc.

#### Definition of Done Checklist:

- [x] Unit tests are added for new features. (newer projects)
- [x] Linting and formatting checks have passed.
- [x] CI/CD pipeline has been successfully executed.
- [x] If an interface has changed, documentation should be updated.

___
