### PR TITLE
fix: pass valid kwargs to Request object inside decorate - Issue #18

### DIFF
--- a/logging_http_client/http_session.py
+++ b/logging_http_client/http_session.py
@@ -2,6 +2,7 @@ import inspect
 import uuid
 from functools import wraps
 from logging import Logger
+from typing import KeysView
 
 from requests import Session, Response, Request, PreparedRequest
 
@@ -20,7 +21,7 @@ class LoggingSession(Session):
     A subclass of requests.Session that logs the request and response details.
     """
 
-    request_class_params = inspect.signature(Request).parameters.keys()
+    REQUEST_CLASS_PARAMS: KeysView[str] = inspect.signature(Request).parameters.keys()
 
     def __init__(self, source: str, logger: Logger) -> None:
         super().__init__()
@@ -44,7 +45,7 @@ class LoggingSession(Session):
     def decorate(self, source: str, logger: Logger, original_method: callable) -> callable:
         @wraps(original_method)
         def _apply(**kwargs) -> Response:
-            request_object_kwargs = {k: v for k, v in kwargs.items() if k in self.request_class_params}
+            request_object_kwargs = {k: v for k, v in kwargs.items() if k in self.REQUEST_CLASS_PARAMS}
             req = Request(**request_object_kwargs)
             prepared: PreparedRequest = self.prepare_request(req)
             request_id = prepared.headers.get(X_REQUEST_ID_HEADER, None)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -12,13 +12,24 @@ def wiremock_server():
 
         # Add a method to the wm object for adding mappings
         def for_endpoint(
-            url, method=HttpMethods.GET, return_status=200, return_body="", headers=None, persistent=False
+            url,
+            method=HttpMethods.GET,
+            return_status=200,
+            return_body="",
+            headers=None,
+            persistent=False,
+            fixed_delay_ms=None,
         ):
-            headers = headers or {"content-type": "application/json"}
+            mapping_response = MappingResponse(
+                status=return_status,
+                body=return_body,
+                headers=headers or {"content-type": "application/json"},
+                fixed_delay_milliseconds=fixed_delay_ms,
+            )
             Mappings.create_mapping(
                 Mapping(
                     request=MappingRequest(method=method, url=url),
-                    response=MappingResponse(status=return_status, body=return_body, headers=headers),
+                    response=mapping_response,
                     persistent=persistent,
                 )
             )

--- a/tests/integration/test_http_client_functional_requirements.py
+++ b/tests/integration/test_http_client_functional_requirements.py
@@ -268,9 +268,7 @@ def test_client_should_raise_timeout_error_on_request_timeout(wiremock_server):
 
 
 @pytest.mark.parametrize("http_method", list(HttpMethod))
-def test_client_does_not_raise_exception_for_expected_optional_arguments(
-    wiremock_server, http_method
-):
+def test_client_does_not_raise_exception_for_expected_optional_arguments(wiremock_server, http_method):
     wiremock_server.for_endpoint(
         "/create", method=http_method.value, return_status=201, return_body='{ "message": "done!" }'
     )

--- a/tests/integration/test_http_client_functional_requirements.py
+++ b/tests/integration/test_http_client_functional_requirements.py
@@ -1,14 +1,15 @@
+import inspect
 import logging
 import uuid
 from logging import LogRecord
-
 import pytest
-from requests import PreparedRequest, Response
+from requests import PreparedRequest, Response, Timeout, Session
 from wiremock.resources.mappings import HttpMethods
 
 import logging_http_client
 from http_headers import X_REQUEST_ID_HEADER, X_SOURCE_HEADER, X_CORRELATION_ID_HEADER
 from logging_http_client import HttpLogRecord
+from logging_http_client.http_methods import HttpMethod
 
 
 def test_client_returns_correct_response_details(wiremock_server):
@@ -250,3 +251,40 @@ def test_client_should_support_traceability(wiremock_server, caplog):
         ), f"Expected request correlation id to be a valid UUID, but got {reqeust_correlation_id}"
     else:
         pytest.fail("Request log does not contain 'http' record attribute")
+
+
+def test_client_should_raise_timeout_error_on_request_timeout(wiremock_server):
+
+    wiremock_server.for_endpoint(
+        "/create", method=HttpMethods.POST, return_status=201, return_body='{ "message": "done!" }', fixed_delay_ms=1000
+    )
+    with pytest.raises(Timeout):
+        logging_http_client.create().post(
+            url=wiremock_server.get_url("/create"),
+            timeout=1,
+            headers={"accept": "application/json"},
+            json='{ "key": "value" }',
+        )
+
+
+@pytest.mark.parametrize("http_method", list(HttpMethod))
+def test_client_does_not_raise_exception_for_expected_optional_arguments(
+    wiremock_server, http_method
+):
+    wiremock_server.for_endpoint(
+        "/create", method=http_method.value, return_status=201, return_body='{ "message": "done!" }'
+    )
+
+    optional_arguments = {
+        key: None
+        for key in inspect.signature(Session.request).parameters.keys()
+        if key not in ["self", "method", "url", "headers"]
+    }
+
+    request_func = getattr(logging_http_client.create(), http_method.value.lower())
+
+    request_func(
+        url=wiremock_server.get_url("/create"),
+        headers={"accept": "application/json"},
+        **optional_arguments,
+    )


### PR DESCRIPTION
### Summary

Use inspect.signature to filter kwargs inside the decorate function, and only pass the valid kwargs to Request initialisation.
Add fixed_delay_ms parameter to WireMock "for_endpoint" to allow timeout testing

#### Definition of Done Checklist:

- [ x] Unit tests are added for new features. (newer projects)
- [ x] Linting and formatting checks have passed.
- [ x] CI/CD pipeline has been successfully executed.
- [ x] If an interface has changed, documentation should be updated.

___
