### PR TITLE
Issue 11 support for default logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ By default, the library logs at the 'INFO' level. To adjust this, use the set_lo
 ```python
 import logging_http_client
 
-logging_http_client.set_logging_level("DEBUG")
+logging_http_client.set_logging_level(logging_http_client.LogLevel.DEBUG)
 
 logging_http_client.create().get('https://www.python.org')
 # => Logs will be recorded at the DEBUG level now.

--- a/README.md
+++ b/README.md
@@ -346,6 +346,18 @@ logging_http_client.create().get('https://www.python.org')
 # => Log record will include the request or response body (if present)
 ```
 
+#### iii. Customizing the logging level
+
+By default, the library logs at the 'INFO' level. To adjust this, use the set_logging_level method. You can specify the desired level as either an integer (10, 20, 30, 40, 50) or a string ("INFO", "DEBUG", etc.).
+```python
+import logging_http_client
+
+logging_http_client.set_logging_level("DEBUG")
+
+logging_http_client.create().get('https://www.python.org')
+# => Logs will be recorded at the DEBUG level now.
+```
+
 ### 5. Obscuring Sensitive Data
 
 The library provides a way to obscure sensitive data in the request or response log records. This is useful when you

--- a/logging_http_client/__init__.py
+++ b/logging_http_client/__init__.py
@@ -78,6 +78,7 @@ from .logging_http_client_config import (  # noqa: F401
     enable_response_body_logging,
     set_logging_level,
 )
+from .log_level import LogLevel  # noqa: F401
 
 
 def create(

--- a/logging_http_client/__init__.py
+++ b/logging_http_client/__init__.py
@@ -76,6 +76,7 @@ from .logging_http_client_config import (  # noqa: F401
     disable_response_logging,
     enable_request_body_logging,
     enable_response_body_logging,
+    set_logging_level,
 )
 
 

--- a/logging_http_client/http_session.py
+++ b/logging_http_client/http_session.py
@@ -37,14 +37,12 @@ class LoggingSession(Session):
             self.options,
         ]
 
-        logging_level = config.get_logging_level()
-
         for method in methods_to_decorate:
             method_name = method.__name__
-            decorated_method = self.decorate(source, logger, method, logging_level)
+            decorated_method = self.decorate(source, logger, method)
             setattr(self, method_name, decorated_method)
 
-    def decorate(self, source: str, logger: Logger, original_method: callable, logging_level: int) -> callable:
+    def decorate(self, source: str, logger: Logger, original_method: callable) -> callable:
         @wraps(original_method)
         def _apply(**kwargs) -> Response:
             request_object_kwargs = {k: v for k, v in kwargs.items() if k in self.REQUEST_CLASS_PARAMS}
@@ -77,6 +75,7 @@ class LoggingSession(Session):
                 request_logging_hook(logger, prepared)
             else:
                 if config.is_request_logging_enabled():
+                    logging_level = config.get_logging_level()
                     logger.log(
                         level=logging_level,
                         msg="REQUEST",
@@ -93,6 +92,7 @@ class LoggingSession(Session):
                 response_logging_hook(logger, response)
             else:
                 if config.is_response_logging_enabled():
+                    logging_level = config.get_logging_level()
                     logger.log(
                         level=logging_level,
                         msg="RESPONSE",

--- a/logging_http_client/log_level.py
+++ b/logging_http_client/log_level.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+from enum import Enum
+
+
+class LogLevel(Enum):
+    """
+    An Enum representing the log levels that are supported by the logging module.
+    """
+
+    DEBUG = 10
+    INFO = 20
+    WARNING = 30
+    ERROR = 40
+    CRITICAL = 50

--- a/logging_http_client/logging_http_client_config.py
+++ b/logging_http_client/logging_http_client_config.py
@@ -127,11 +127,11 @@ def set_logging_level(level: str | int = 20) -> None:
     if isinstance(level, str):
         level = level.upper()
         numeric_level = getattr(logging, level, None)
-        if not isinstance(numeric_level, int):
-            raise ValueError(f"Invalid log level: {level}")
+        if not numeric_level:
+            numeric_level = 20
     elif isinstance(level, int):
-        numeric_level = level
-    else:
-        raise ValueError(f"Log level must be a string or an integer, got {type(level)}")
-    print(f"Logging level set to {numeric_level}")
+        if not 0 <= level <= 50 or level % 10 != 0:
+            numeric_level = 20
+        else:
+            numeric_level = level
     config.set_logging_level(numeric_level)

--- a/logging_http_client/logging_http_client_config.py
+++ b/logging_http_client/logging_http_client_config.py
@@ -116,3 +116,22 @@ def enable_response_body_logging(enable: bool = True) -> None:
         these are for modifying the default logging setup)
     """
     config.set_response_body_logging_enabled(enable)
+
+
+def set_logging_level(level: str | int = 20) -> None:
+    """
+    Set the logging level for the logger. Default is 20 which represents 'INFO'.
+
+    The level should be a string such as 'DEBUG', 'INFO', 'WARNING', 'ERROR', or 'CRITICAL'.
+    """
+    if isinstance(level, str):
+        level = level.upper()
+        numeric_level = getattr(logging, level, None)
+        if not isinstance(numeric_level, int):
+            raise ValueError(f"Invalid log level: {level}")
+    elif isinstance(level, int):
+        numeric_level = level
+    else:
+        raise ValueError(f"Log level must be a string or an integer, got {type(level)}")
+    print(f"Logging level set to {numeric_level}")
+    config.set_logging_level(numeric_level)

--- a/logging_http_client/logging_http_client_config.py
+++ b/logging_http_client/logging_http_client_config.py
@@ -11,6 +11,7 @@ from requests import Response, PreparedRequest
 
 import logging_http_client.logging_http_client_config_globals as config
 from logging_http_client.http_log_record import HttpLogRecord
+from logging_http_client.log_level import LogLevel
 
 CorrelationIdProviderType = Optional[Callable[[], str]]
 
@@ -118,20 +119,14 @@ def enable_response_body_logging(enable: bool = True) -> None:
     config.set_response_body_logging_enabled(enable)
 
 
-def set_logging_level(level: str | int = 20) -> None:
+def set_logging_level(level: LogLevel) -> None:
     """
     Set the logging level for the logger. Default is 20 which represents 'INFO'.
 
     The level should be a string such as 'DEBUG', 'INFO', 'WARNING', 'ERROR', or 'CRITICAL'.
     """
-    if isinstance(level, str):
-        level = level.upper()
-        numeric_level = getattr(logging, level, None)
-        if not numeric_level:
-            numeric_level = 20
-    elif isinstance(level, int):
-        if not 0 <= level <= 50 or level % 10 != 0:
-            numeric_level = 20
-        else:
-            numeric_level = level
-    config.set_logging_level(numeric_level)
+    if not isinstance(level, LogLevel):
+        level = LogLevel.INFO
+
+    print(f"Setting logging level to {level.value}")
+    config.set_logging_level(level.value)

--- a/logging_http_client/logging_http_client_config.py
+++ b/logging_http_client/logging_http_client_config.py
@@ -128,5 +128,4 @@ def set_logging_level(level: LogLevel) -> None:
     if not isinstance(level, LogLevel):
         level = LogLevel.INFO
 
-    print(f"Setting logging level to {level.value}")
     config.set_logging_level(level.value)

--- a/logging_http_client/logging_http_client_config_globals.py
+++ b/logging_http_client/logging_http_client_config_globals.py
@@ -122,3 +122,18 @@ def set_request_body_logging_enabled(value: bool):
 def set_response_body_logging_enabled(value: bool):
     global _response_body_logging_enabled
     _response_body_logging_enabled = value
+
+
+# Request/Response Logging Toggle =============================================
+
+_logging_level: int = 20  # 20 is the default logging level for logging.INFO
+
+
+def set_logging_level(value: int):
+    global _logging_level
+    _logging_level = value
+
+
+def get_logging_level():
+    global _logging_level
+    return _logging_level

--- a/logging_http_client/logging_http_client_config_globals.py
+++ b/logging_http_client/logging_http_client_config_globals.py
@@ -5,6 +5,8 @@ We separate the configuration globals and getters from the main configuration mo
 avoid circular imports when using the configuration getters within the implementation code.
 """
 
+from logging_http_client.log_level import LogLevel
+
 # Correlation ID Provider =====================================================
 
 _correlation_id_provider = None
@@ -126,7 +128,7 @@ def set_response_body_logging_enabled(value: bool):
 
 # Request/Response Logging Toggle =============================================
 
-_logging_level: int = 20  # 20 is the default logging level for logging.INFO
+_logging_level: int = LogLevel.INFO.value
 
 
 def set_logging_level(value: int):

--- a/tests/unit/test_logging_default_config.py
+++ b/tests/unit/test_logging_default_config.py
@@ -5,8 +5,11 @@ from logging_http_client.logging_http_client_config import (
     enable_request_body_logging,
     disable_response_logging,
     enable_response_body_logging,
+    set_logging_level,
 )
 import logging_http_client.logging_http_client_config_globals as config
+
+level_map = {"INFO": 20, "DEBUG": 10, "WARNING": 30, "ERROR": 40, "CRITICAL": 50}
 
 
 @pytest.mark.parametrize("switch", [True, False])
@@ -31,3 +34,21 @@ def test_enable_response_logging(switch):
 def test_enable_response_body_logging(switch):
     enable_response_body_logging(switch)
     assert config.is_response_body_logging_enabled() == switch
+
+
+@pytest.mark.parametrize("switch", [10, 20, 30, 40, 50])
+def test_set_logging_level(switch):
+    set_logging_level(switch)
+    assert config.get_logging_level() == switch
+
+
+@pytest.mark.parametrize("switch", ["INFO", "DEBUG", "WARNING", "ERROR", "CRITICAL"])
+def test_set_logging_level_string(switch):
+    set_logging_level(switch)
+    assert config.get_logging_level() == level_map[switch]
+
+
+@pytest.mark.parametrize("switch", ["INVALID", "INFODEBUG", 60, 11, 35, 45, 11010210120201, None])
+def test_set_logging_level_edgecases(switch):
+    set_logging_level(switch) == 20
+    assert config.get_logging_level() == 20

--- a/tests/unit/test_logging_default_config.py
+++ b/tests/unit/test_logging_default_config.py
@@ -6,10 +6,9 @@ from logging_http_client.logging_http_client_config import (
     disable_response_logging,
     enable_response_body_logging,
     set_logging_level,
+    LogLevel,
 )
 import logging_http_client.logging_http_client_config_globals as config
-
-level_map = {"INFO": 20, "DEBUG": 10, "WARNING": 30, "ERROR": 40, "CRITICAL": 50}
 
 
 @pytest.mark.parametrize("switch", [True, False])
@@ -36,16 +35,22 @@ def test_enable_response_body_logging(switch):
     assert config.is_response_body_logging_enabled() == switch
 
 
-@pytest.mark.parametrize("switch", [10, 20, 30, 40, 50])
-def test_set_logging_level(switch):
+@pytest.mark.parametrize("switch", [LogLevel.INFO, LogLevel.DEBUG, LogLevel.WARNING, LogLevel.ERROR, LogLevel.CRITICAL])
+def test_set_logging_level_enum(switch):
     set_logging_level(switch)
-    assert config.get_logging_level() == switch
+    assert config.get_logging_level() == switch.value
+
+
+@pytest.mark.parametrize("switch", [10, 20, 30, 40, 50])
+def test_set_logging_level_int(switch):
+    set_logging_level(switch)
+    assert config.get_logging_level() == 20
 
 
 @pytest.mark.parametrize("switch", ["INFO", "DEBUG", "WARNING", "ERROR", "CRITICAL"])
 def test_set_logging_level_string(switch):
     set_logging_level(switch)
-    assert config.get_logging_level() == level_map[switch]
+    assert config.get_logging_level() == 20
 
 
 @pytest.mark.parametrize("switch", ["INVALID", "INFODEBUG", 60, 11, 35, 45, 11010210120201, None])


### PR DESCRIPTION
### Summary

Within our default REQUEST and RESPONSE logging hook, the log level was hardcoded to INFO. This PR makes the log_level customizable so that users have the ability to specify the log level for their logs. (Issue #11)

### Changes

- `logging_http_client/logging_http_client_config_globals.py` - added a new global variable that will keep a track of the log_level
- `logging_http_client/logging_http_client_config.py` - added a method to modify the global variable. This will be called by the users.
- `logging_http_client/__init__.py` - added the new method so that it can be called.
- logging_http_client/http_session.py` - updated the logic so that logger is called using the log function and the level is passed a parameter.
- `README.md` - updated documentation to reflect the new feature.
- `tests/unit/test_logging_default_config.py` - added tests for the `set_logging_level` method

#### Definition of Done Checklist:

- [x] Unit tests are added for new features. (newer projects)
- [x] Linting and formatting checks have passed.
- [ ] CI/CD pipeline has been successfully executed.
- [x] If an interface has changed, documentation should be updated.

___
